### PR TITLE
staging/DynamoDBのテーブル設計を修正

### DIFF
--- a/environments/staging/dynamodb.tf
+++ b/environments/staging/dynamodb.tf
@@ -1,11 +1,22 @@
 resource "aws_dynamodb_table" "dynamodb" {
-  name         = "Emails-staging"
+  name         = "Users-staging"
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "Email"
+  hash_key     = "UserId"
+
+  attribute {
+    name = "UserId"
+    type = "S"
+  }
 
   attribute {
     name = "Email"
     type = "S"
+  }
+
+  global_secondary_index {
+    name            = "EmailIndex"
+    hash_key        = "Email"
+    projection_type = "ALL"
   }
 
   tags = {


### PR DESCRIPTION
ユニークなIDをハッシュキーとして使用するよう修正。メールアドレスをハッシュキーとして使うのをやめることでログに個人情報が露出するリスクを軽減。代わりにUUIDをハッシュキーとして設定する。その代わりにグローバルセカンダリインデックスも設定。