### PR TITLE
staging/seedデータの投入

### DIFF
--- a/environments/staging/dynamodb.tf
+++ b/environments/staging/dynamodb.tf
@@ -1,4 +1,4 @@
-resource "aws_dynamodb_table" "dynamodb" {
+resource "aws_dynamodb_table" "users" {
   name         = "Users-staging"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "UserId"
@@ -32,13 +32,14 @@ resource "aws_dynamodb_table" "dynamodb" {
 }
 
 # resource "aws_dynamodb_table_item" を使うとテスト用のseedデータが投入できる
-# resource "aws_dynamodb_table_item" "dynamodb_item" {
-#   table_name = aws_dynamodb_table.dynamodb.name
-#   hash_key   = aws_dynamodb_table.dynamodb.hash_key
+resource "aws_dynamodb_table_item" "seed_email_items" {
+  count = length(var.seed_emails)
 
-#   item = <<-EOT
-#     {
-#       "Email": { "S": "example@example.com" }
-#     }
-#   EOT
-# }
+  table_name = aws_dynamodb_table.users.name
+  hash_key   = aws_dynamodb_table.users.hash_key
+
+  item = jsonencode({
+    UserId = { "S" = uuid() }
+    Email  = { "S" = var.seed_emails[count.index] }
+  })
+}

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -1,0 +1,5 @@
+variable "seed_emails" {
+  description = "DynamoDBテーブルに挿入するメールアドレスのリスト"
+  type        = list(string)
+  sensitive   = true
+}


### PR DESCRIPTION
`terraform apply`実行時に以下のエラーが出た。
```
│ Error: Invalid format of "item": unexpected raw attribute type: string
│ 
│   with aws_dynamodb_table_item.seed_email_items[0],
│   on dynamodb.tf line 41, in resource "aws_dynamodb_table_item" "seed_email_items":
│   41:   item = jsonencode({
│   42:     UserId = uuid()
│   43:     Email  = var.seed_emails[count.index]
│   44:   })
```

DynamoDB にデータを投入する際、各属性には以下のようにデータ型の指定が必要。

修正前のコード
```
resource "aws_dynamodb_table_item" "seed_email_items" {
  count = length(var.seed_emails)

  table_name = aws_dynamodb_table.users.name
  hash_key   = aws_dynamodb_table.users.hash_key

  item = jsonencode({
    UserId = uuid()
    Email  = var.seed_emails[count.index]
  })
}
```

修正後のコード
```
resource "aws_dynamodb_table_item" "seed_email_items" {
  count = length(var.seed_emails)

  table_name = aws_dynamodb_table.users.name
  hash_key   = aws_dynamodb_table.users.hash_key

  item = jsonencode({
    UserId = { "S" = uuid() }
    Email  = { "S" = var.seed_emails[count.index] }
  })
}
```